### PR TITLE
feature/#7: 로그아웃시 액세스 토큰도 같이 사용 불가 로직 추가

### DIFF
--- a/app/src/models/auth/authRepository.js
+++ b/app/src/models/auth/authRepository.js
@@ -3,7 +3,7 @@
 import db from "../../config/db.js";
 
 class AuthRepository {
-  static findAccessToken(userNo) {
+  static findToken(userNo) {
     const query = "SELECT * FROM token where user_no = ?;";
     return db.query(query, [userNo]);
   }
@@ -14,13 +14,13 @@ class AuthRepository {
     return db.query(query, [userNo, userRefreshToken, userAccessToken]);
   }
 
-  static async refreshTokenCheck(clientRefreshToken) {
+  static async refreshTokenFind(clientRefreshToken) {
     const query = "SELECT * FROM token WHERE refresh_token = ?;";
     const [users, field] = await db.query(query, [clientRefreshToken]);
     return users[0];
   }
 
-  static deleteRefreshToken(userNo) {
+  static deleteToken(userNo) {
     const query = "DELETE FROM token WHERE user_no = ?;";
     return db.query(query, [userNo]);
   }

--- a/app/src/models/auth/authRepository.js
+++ b/app/src/models/auth/authRepository.js
@@ -3,21 +3,26 @@
 import db from "../../config/db.js";
 
 class AuthRepository {
-  static tokenSave(userNo, userRefreshToken) {
+  static findAccessToken(userNo) {
+    const query = "SELECT * FROM token where user_no = ?;";
+    return db.query(query, [userNo]);
+  }
+
+  static tokenSave(userNo, userRefreshToken, userAccessToken) {
     const query =
-      "INSERT INTO token (`user_no`, `refresh_token`) VALUES (?, ?)";
-    return db.query(query, [userNo, userRefreshToken]);
+      "INSERT INTO token (`user_no`, `refresh_token`, `access_token`) VALUES (?, ?, ?)";
+    return db.query(query, [userNo, userRefreshToken, userAccessToken]);
   }
 
   static async refreshTokenCheck(clientRefreshToken) {
     const query = "SELECT * FROM token WHERE refresh_token = ?;";
     const [users, field] = await db.query(query, [clientRefreshToken]);
     return users[0];
-  };
+  }
 
   static deleteRefreshToken(userNo) {
-    const query = "DELETE FROM token WHERE user_no = ?;"
+    const query = "DELETE FROM token WHERE user_no = ?;";
     return db.query(query, [userNo]);
   }
-};
+}
 export default AuthRepository;

--- a/app/src/models/auth/authService.js
+++ b/app/src/models/auth/authService.js
@@ -13,26 +13,26 @@ class AuthService {
     this.user = req.user;
   }
   async checkAccessToken() {
-    const accessToken = this.user;
+    const user = this.user;
 
-    const [users, field] = await AuthRepository.findAccessToken(accessToken.no);
-    if (!users[0]) {
+    const [tokens, field] = await AuthRepository.findToken(user.no);
+    if (!tokens[0]) {
       return {
-        error: "Not Found",
+        error: "Unauthorized",
         message: "유저의 액세스 토큰 정보가 없습니다.",
-        statusCode: 404,
+        statusCode: 401,
       };
     }
     return {
-      statusCode: 201,
+      statusCode: 200,
       message: "정상적인 액세스 토큰입니다.",
     };
   }
 
   async logout() {
-    const accessToken = this.user;
-    const logoutResult = await AuthRepository.deleteRefreshToken(
-      accessToken.no
+    const user = this.user;
+    const logoutResult = await AuthRepository.deleteToken(
+      user.no
     );
     if (!logoutResult[0].affectedRows) {
       return {
@@ -41,7 +41,10 @@ class AuthService {
         statuscode: 500,
       };
     }
-    return { statusCode: 201, message: "로그아웃에 성공하였습니다." };
+    return {
+      statusCode: 204,
+      message: "로그아웃에 성공하였습니다.",
+    };
   }
 
   async login() {
@@ -137,7 +140,7 @@ class AuthService {
     return {
       message: "액세스 토큰 재발급 완료됐습니다.",
       accessToken,
-      statusCode: 200,
+      statusCode: 201,
     };
   }
 }

--- a/app/src/models/auth/authService.js
+++ b/app/src/models/auth/authService.js
@@ -11,15 +11,38 @@ class AuthService {
     this.params = req.params;
     this.headers = req.headers;
     this.user = req.user;
-  };
+  }
+  async checkAccessToken() {
+    const accessToken = this.user;
+
+    const [users, field] = await AuthRepository.findAccessToken(accessToken.no);
+    if (!users[0]) {
+      return {
+        error: "Not Found",
+        message: "유저의 액세스 토큰 정보가 없습니다.",
+        statusCode: 404,
+      };
+    }
+    return {
+      statusCode: 201,
+      message: "정상적인 액세스 토큰입니다.",
+    };
+  }
+
   async logout() {
     const accessToken = this.user;
-    const logoutResult = await AuthRepository.deleteRefreshToken(accessToken.no);
+    const logoutResult = await AuthRepository.deleteRefreshToken(
+      accessToken.no
+    );
     if (!logoutResult[0].affectedRows) {
-      return { error: "Internal Server Error", message: "로그아웃에 실패하였습니다.", statuscode: 500 };
+      return {
+        error: "Internal Server Error",
+        message: "로그아웃에 실패하였습니다.",
+        statuscode: 500,
+      };
     }
     return { statusCode: 201, message: "로그아웃에 성공하였습니다." };
-  };
+  }
 
   async login() {
     const loginRequestBody = this.body;
@@ -55,7 +78,7 @@ class AuthService {
       no: users[0].no,
     });
 
-    await AuthRepository.tokenSave(users[0].no, refreshToken);
+    await AuthRepository.tokenSave(users[0].no, refreshToken, accessToken);
 
     return {
       message: "로그인에 성공하였습니다.",

--- a/app/src/routes/auth/authCtrl.js
+++ b/app/src/routes/auth/authCtrl.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import AuthService from "../../models/auth/authService.js"
+import AuthService from "../../models/auth/authService.js";
 
 const process = {
   login: async (req, res) => {
@@ -16,8 +16,13 @@ const process = {
   logout: async (req, res) => {
     const auth = new AuthService(req);
     const response = await auth.logout();
-    return res.json(response).status(response.statusCode)
-  }
+    return res.json(response).status(response.statusCode);
+  },
+  checkToken: async (req, res) => {
+    const auth = new AuthService(req);
+    const response = await auth.checkAccessToken();
+    return res.json(response).status(response.statusCode);
+  },
 };
 export default {
   process,

--- a/app/src/routes/auth/authMiddleware.js
+++ b/app/src/routes/auth/authMiddleware.js
@@ -34,11 +34,11 @@ const tokenProcess = {
       );
       console.log("토큰 인증 성공", payload);
 
-      req.user = {...payload};
+      req.user = { ...payload };
       const auth = new AuthService(req);
       const response = await auth.checkAccessToken();
 
-      if (response.statusCode === 404) {
+      if (response.statusCode === 401) {
         return res.status(response.statusCode).json(response);
       }
       next();

--- a/app/src/routes/auth/authMiddleware.js
+++ b/app/src/routes/auth/authMiddleware.js
@@ -2,11 +2,12 @@
 
 import jwt from "jsonwebtoken";
 
+import AuthService from "../../models/auth/authService.js";
+import ctrl from "./authCtrl.js";
+
 const tokenProcess = {
   accessToken: async (req, res, next) => {
-
-    const token = req.headers['authorization'];
-
+    const token = req.headers["authorization"];
 
     if (!token) {
       const response = {
@@ -15,28 +16,44 @@ const tokenProcess = {
         statusCode: 400,
       };
       return res.status(response.statusCode).json(response);
-    };
+    }
 
-    const [type, clientAccessToken] = token.split(' ');
+    const [type, clientAccessToken] = token.split(" ");
     if (type !== "Bearer") {
-      return { error: 'Bad Request', message: "잘못된 토큰 타입입니다.", statusCode: 400 };
-    };
+      return {
+        error: "Bad Request",
+        message: "잘못된 토큰 타입입니다.",
+        statusCode: 400,
+      };
+    }
 
     try {
-      const payload = jwt.verify(clientAccessToken, process.env.ACCESS_TOKEN_SECRET);
-      console.log('토큰 인증 성공', payload);
+      const payload = jwt.verify(
+        clientAccessToken,
+        process.env.ACCESS_TOKEN_SECRET
+      );
+      console.log("토큰 인증 성공", payload);
 
-      req.user = { ...payload };
+      req.user = {...payload};
+      const auth = new AuthService(req);
+      const response = await auth.checkAccessToken();
 
+      if (response.statusCode === 404) {
+        return res.status(response.statusCode).json(response);
+      }
       next();
     } catch (err) {
       console.log("유효하지 않은 토큰입니다.");
 
-      const response = { error: 'Unauthorized', message: err.message, statusCode: 401 };
+      const response = {
+        error: "Unauthorized",
+        message: err.message,
+        statusCode: 401,
+      };
 
       return res.status(response.statusCode).json(response);
-    };
-  }
+    }
+  },
 };
 export default {
   tokenProcess,


### PR DESCRIPTION
클라이언트 쪽에서 로그아웃을 해도 리프레시 토큰만 db에 저장되어 있어 삭제해도 만료가 되지 않은 액세스 토큰으로 사이트를 돌아다닐 수 있어 로그인 시 액세스 토큰도 저장하고 로그아웃 요청 시 유저 액세스 토큰과 리프레시 토큰 둘 다 삭제합니다. 그리고 미들웨어에 액세스 토큰 만료 여부를 확인하고 받은 payload 값 중 유저 고유 번호를 뽑아서 db상에 해당 유저의 토큰 데이터가 있는지 검사하는 로직을 추가했습니다. 최종적으로 로그아웃시 클라이언트에 로컬에는 유효한 액세스 토큰이 있지만 미들웨어에서 검사했을 때 db상에는 해당 유저의 토큰 값이 없기 때문에 에러를 리턴합니다.